### PR TITLE
Remove "lodash" dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,6 @@ var gutil = require('gulp-util');
 var mocha = require('gulp-mocha');
 var istanbul = require('gulp-istanbul');
 var printExample = require('./lib/print-example');
-var _ = require('lodash');
 
 gulp.task('test',mochaTask);
 gulp.task('coverage',coverage());

--- a/lib/print-example.js
+++ b/lib/print-example.js
@@ -1,7 +1,6 @@
 var chai = require('chai');
 var expect = chai.expect;
 var colors = require('colors/safe');
-var _ = require('lodash');
 var fs = require('fs');
 var git = require('git-rev');
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
+    "object-assign": "^4.1.0",
     "string-width": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "kind-of": "^3.0.4",
     "object-assign": "^4.1.0",
     "string-width": "^1.0.1"
   },

--- a/src/cell.js
+++ b/src/cell.js
@@ -36,7 +36,7 @@ Cell.prototype.mergeTableOptions = function(tableOptions,cells){
   var optionsChars = this.options.chars || {};
   var tableChars = tableOptions.chars;
   var chars = this.chars = {};
-  _.forEach(CHAR_NAMES,function(name){
+  CHAR_NAMES.forEach(function(name){
      setOption(optionsChars,tableChars,name,chars);
   });
 
@@ -132,7 +132,7 @@ Cell.prototype.draw = function(lineNum,spanningCell){
 Cell.prototype.drawTop = function(drawRight){
   var content = [];
   if(this.cells){  //TODO: cells should always exist - some tests don't fill it in though
-    _.forEach(this.widths,function(width,index){
+    this.widths.forEach(function(width,index){
       content.push(this._topLeftChar(index));
       content.push(
         utils.repeat(this.chars[this.y == 0 ? 'top' : 'mid'],width)

--- a/src/cell.js
+++ b/src/cell.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var kindOf = require('kind-of');
 var utils = require('./utils');
 
 /**
@@ -13,13 +13,13 @@ function Cell(options){
 }
 
 Cell.prototype.setOptions = function(options){
-  if(_.isString(options) || _.isNumber(options) || _.isBoolean(options)){
+  if(['boolean', 'number', 'string'].indexOf(kindOf(options)) !== -1){
     options = {content:''+options};
   }
   options = options || {};
   this.options = options;
   var content = options.content;
-  if (_.isString(content) || _.isNumber(content) || _.isBoolean(content)) {
+  if (['boolean', 'number', 'string'].indexOf(kindOf(content)) !== -1) {
     this.content = String(content);
   } else if (!content) {
     this.content = '';

--- a/src/cell.js
+++ b/src/cell.js
@@ -85,8 +85,8 @@ Cell.prototype.init = function(tableOptions){
   var y = this.y;
   this.widths = tableOptions.colWidths.slice(x, x + this.colSpan);
   this.heights = tableOptions.rowHeights.slice(y, y + this.rowSpan);
-  this.width = _.reduce(this.widths,sumPlusOne);
-  this.height = _.reduce(this.heights,sumPlusOne);
+  this.width = this.widths.reduce(sumPlusOne, -1);
+  this.height = this.heights.reduce(sumPlusOne, -1);
 
   this.hAlign = this.options.hAlign || tableOptions.colAligns[x];
   this.vAlign = this.options.vAlign || tableOptions.rowAligns[y];

--- a/src/layout-manager.js
+++ b/src/layout-manager.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var objectAssign = require('object-assign');
 var Cell = require('./cell');
 var RowSpanCell = Cell.RowSpanCell;
 var ColSpanCell = Cell.ColSpanCell;
@@ -227,7 +228,7 @@ function makeComputeWidths(colSpan,desiredWidth,x,forcedMin){
       }
     }
 
-    _.extend(vals,result);
+    objectAssign(vals,result);
     for(var j = 0; j < vals.length; j++){
       vals[j] = Math.max(forcedMin, vals[j] || 0);
     }

--- a/src/layout-manager.js
+++ b/src/layout-manager.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var kindOf = require('kind-of');
 var objectAssign = require('object-assign');
 var Cell = require('./cell');
 var RowSpanCell = Cell.RowSpanCell;
@@ -143,10 +143,10 @@ var ColSpanCell = Cell.ColSpanCell;
 
   function generateCells(rows){
     return rows.map(function(row){
-      if(!_.isArray(row)){
+      if(kindOf(row) !== 'array'){
         var key = Object.keys(row)[0];
         row = row[key];
-        if(_.isArray(row)){
+        if(kindOf(row) === 'array'){
           row = row.slice();
           row.unshift(key);
         }
@@ -196,7 +196,7 @@ function makeComputeWidths(colSpan,desiredWidth,x,forcedMin){
     });
 
     vals.forEach(function(val,index){
-      if(_.isNumber(val)){
+      if(kindOf(val) === 'number'){
         result[index] = val;
       }
     });
@@ -207,17 +207,17 @@ function makeComputeWidths(colSpan,desiredWidth,x,forcedMin){
       var span = cell[colSpan];
       var col = cell[x];
       var existingWidth = result[col];
-      var editableCols = _.isNumber(vals[col]) ? 0 : 1;
+      var editableCols = kindOf(vals[col]) === 'number' ? 0 : 1;
       for(var i = 1; i < span; i ++){
         existingWidth += 1 + result[col + i];
-        if(!_.isNumber(vals[col + i])){
+        if(kindOf(vals[col + i]) !== 'number'){
           editableCols++;
         }
       }
       if(cell[desiredWidth] > existingWidth){
         i = 0;
         while(editableCols > 0 && cell[desiredWidth] > existingWidth){
-          if(!_.isNumber(vals[col+i])){
+          if(kindOf(vals[col+i]) !== 'number'){
             var dif = Math.round( (cell[desiredWidth] - existingWidth) / editableCols );
             existingWidth += dif;
             result[col + i] += dif;

--- a/src/layout-manager.js
+++ b/src/layout-manager.js
@@ -5,8 +5,8 @@ var ColSpanCell = Cell.ColSpanCell;
 
 (function(){
   function layoutTable(table){
-    _.forEach(table,function(row,rowIndex){
-      _.forEach(row,function(cell,columnIndex){
+    table.forEach(function(row,rowIndex){
+      row.forEach(function(cell,columnIndex){
         cell.y = rowIndex;
         cell.x = columnIndex;
         for(var y = rowIndex; y >= 0; y--){
@@ -25,8 +25,8 @@ var ColSpanCell = Cell.ColSpanCell;
 
   function maxWidth(table) {
     var mw = 0;
-    _.forEach(table, function (row) {
-      _.forEach(row, function (cell) {
+    table.forEach(function (row) {
+      row.forEach(function (cell) {
         mw = Math.max(mw,cell.x + (cell.colSpan || 1));
       });
     });
@@ -77,8 +77,8 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function addRowSpanCells(table){
-    _.forEach(table,function(row,rowIndex){
-      _.forEach(row,function(cell){
+    table.forEach(function(row,rowIndex){
+      row.forEach(function(cell){
         for(var i = 1; i < cell.rowSpan; i++){
           var rowSpanCell = new RowSpanCell(cell);
           rowSpanCell.x = cell.x;
@@ -141,7 +141,7 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function generateCells(rows){
-    return _.map(rows,function(row){
+    return rows.map(function(row){
       if(!_.isArray(row)){
         var key = Object.keys(row)[0];
         row = row[key];
@@ -153,7 +153,7 @@ var ColSpanCell = Cell.ColSpanCell;
           row = [key,row];
         }
       }
-      return _.map(row,function(cell){
+      return row.map(function(cell){
         return new Cell(cell);
       });
     });
@@ -183,8 +183,8 @@ function makeComputeWidths(colSpan,desiredWidth,x,forcedMin){
   return function(vals,table){
     var result = [];
     var spanners = [];
-    _.forEach(table,function(row){
-      _.forEach(row,function(cell){
+    table.forEach(function(row){
+      row.forEach(function(cell){
         if((cell[colSpan] || 1) > 1){
           spanners.push(cell);
         }
@@ -194,13 +194,13 @@ function makeComputeWidths(colSpan,desiredWidth,x,forcedMin){
       });
     });
 
-    _.forEach(vals,function(val,index){
+    vals.forEach(function(val,index){
       if(_.isNumber(val)){
         result[index] = val;
       }
     });
 
-    //_.forEach(spanners,function(cell){
+    //spanners.forEach(function(cell){
     for(var k = spanners.length - 1; k >=0; k--){
       var cell = spanners[k];
       var span = cell[colSpan];

--- a/src/table.js
+++ b/src/table.js
@@ -1,7 +1,5 @@
-
 var utils = require('./utils');
 var tableLayout = require('./layout-manager');
-var _ = require('lodash');
 
 function Table(options){
   this.options = utils.mergeOptions(options);
@@ -24,8 +22,8 @@ Table.prototype.toString = function(){
 
   var cells = tableLayout.makeTableLayout(array);
 
-  _.forEach(cells,function(row){
-    _.forEach(row,function(cell){
+  cells.forEach(function(row){
+    row.forEach(function(cell){
       cell.mergeTableOptions(this.options,cells);
     },this);
   },this);
@@ -33,8 +31,8 @@ Table.prototype.toString = function(){
   tableLayout.computeWidths(this.options.colWidths,cells);
   tableLayout.computeHeights(this.options.rowHeights,cells);
 
-  _.forEach(cells,function(row,rowIndex){
-    _.forEach(row,function(cell,cellIndex){
+  cells.forEach(function(row,rowIndex){
+    row.forEach(function(cell,cellIndex){
       cell.init(this.options);
     },this);
   },this);
@@ -63,7 +61,7 @@ Table.prototype.toString = function(){
 
 function doDraw(row,lineNum,result){
   var line = [];
-  _.forEach(row,function(cell){
+  row.forEach(function(cell){
     line.push(cell.draw(lineNum));
   });
   var str = line.join('');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var objectAssign = require('object-assign');
 var stringWidth = require('string-width');
 
 function codeRegex(capture){
@@ -236,9 +236,9 @@ function defaultOptions(){
 function mergeOptions(options,defaults){
   options = options || {};
   defaults = defaults || defaultOptions();
-  var ret = _.extend({}, defaults, options);
-  ret.chars = _.extend({}, defaults.chars, options.chars);
-  ret.style = _.extend({}, defaults.style, options.style);
+  var ret = objectAssign({}, defaults, options);
+  ret.chars = objectAssign({}, defaults.chars, options.chars);
+  ret.style = objectAssign({}, defaults.style, options.style);
   return ret;
 }
 
@@ -287,7 +287,7 @@ function colorizeLines(input){
   for(var i = 0; i < input.length; i++){
     var line = rewindState(state,input[i]) ;
     state = readState(line);
-    var temp = _.extend({},state);
+    var temp = objectAssign({},state);
     output.push(unwindState(temp,line));
   }
   return output;

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,8 +104,8 @@ function unwindState(state,ret){
   delete state.lastBackgroundAdded;
   delete state.lastForegroundAdded;
 
-  _.forEach(state,function(value,key){
-    if(value){
+  Object.keys(state).forEach(function(key){
+    if(state[key]){
       ret += codeCache[key].off;
     }
   });
@@ -127,8 +127,8 @@ function rewindState(state,ret){
   delete state.lastBackgroundAdded;
   delete state.lastForegroundAdded;
 
-  _.forEach(state,function(value,key){
-    if(value){
+  Object.keys(state).forEach(function(key){
+    if(state[key]){
       ret = codeCache[key].on + ret;
     }
   });

--- a/test/table-layout-test.js
+++ b/test/table-layout-test.js
@@ -10,7 +10,7 @@ describe('tableLayout', function () {
   var computeHeights = layoutManager.computeHeights;
   var chai = require('chai');
   var expect = chai.expect;
-  var _ = require('lodash');
+  var kindOf = require('kind-of');
 
   it('simple 2x2 layout',function(){
     var actual = makeTableLayout([
@@ -437,7 +437,7 @@ describe('tableLayout', function () {
   }
 
   function checkExpectation(actualCell,expectedCell,x,y,actualTable){
-    if(_.isString(expectedCell)){
+    if(kindOf(expectedCell) === 'string'){
       expectedCell = {content:expectedCell};
     }
     var address = '(' + y + ',' + x + ')';

--- a/test/table-layout-test.js
+++ b/test/table-layout-test.js
@@ -414,8 +414,8 @@ describe('tableLayout', function () {
    */
 
   function checkLayout(actualTable,expectedTable){
-    _.forEach(expectedTable,function(expectedRow,y){
-      _.forEach(expectedRow,function(expectedCell,x){
+    expectedTable.forEach(function(expectedRow,y){
+      expectedRow.forEach(function(expectedCell,x){
         if(expectedCell !== null){
           var actualCell = findCell(actualTable,x,y);
           checkExpectation(actualCell,expectedCell,x,y,actualTable);


### PR DESCRIPTION
This PR replaces the large "lodash" dependency with native methods, an `Object.assign()` polyfill and the `kind-of` library.

Resolves another part of #25 