### PR TITLE
Fix emoji length calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "kind-of": "^3.0.4",
     "object-assign": "^4.1.0",
-    "string-width": "^1.0.1"
+    "stringz": "^0.4.0"
   },
   "devDependencies": {
     "ansi-256-colors": "^1.1.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 var objectAssign = require('object-assign');
-var stringWidth = require('string-width');
+var stringz = require('stringz');
 
 function codeRegex(capture){
   return capture ? /\u001b\[((?:\d*;){0,5}\d*)m/g : /\u001b\[(?:\d*;){0,5}\d*m/g
@@ -9,7 +9,7 @@ function strlen(str){
   var code = codeRegex();
   var stripped = ("" + str).replace(code,'');
   var split = stripped.split("\n");
-  return split.reduce(function (memo, s) { return (stringWidth(s) > memo) ? stringWidth(s) : memo }, 0);
+  return split.reduce(function (memo, s) { return (stringz.length(s) > memo) ? stringz.length(s) : memo }, 0);
 }
 
 function repeat(str,times){


### PR DESCRIPTION
I have a problem of using emoji flag on the table. 
<img width="91" alt="screen shot 2018-01-10 at 10 13 32 am" src="https://user-images.githubusercontent.com/5042222/34788322-0f0fe870-f5ef-11e7-90f4-85338502f6b2.png">
It does not calculate the length of emoji correctly. `"🇨🇦".length == 2` but it should be 1. 

This PR is to use [Stringz](https://github.com/sallar/stringz) to calculate the length of emoji and the following screenshot is the correct output:
<img width="92" alt="screen shot 2018-01-10 at 10 13 55 am" src="https://user-images.githubusercontent.com/5042222/34788537-bb9c3a62-f5ef-11e7-9981-1494a30f3480.png">

