### PR TITLE
Ignore combining character U+0336 in string length calculation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ var objectAssign = require('object-assign');
 var stringWidth = require('string-width');
 
 function codeRegex(capture){
-  return capture ? /\u001b\[((?:\d*;){0,5}\d*)m/g : /\u001b\[(?:\d*;){0,5}\d*m/g
+  return capture ? /\u0336|\u001b\[((?:\d*;){0,5}\d*)m/g : /\u0336|\u001b\[(?:\d*;){0,5}\d*m/g
 }
 
 function strlen(str){

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -17,6 +17,10 @@ describe('utils',function(){
       expect(strlen('hello')).to.equal(5);
     });
 
+    it('length of "h\u0336e\u0336l\u0336l\u0336o\u0336" is 5',function(){
+      expect(strlen('h\u0336e\u0336l\u0336l\u0336o\u0336')).to.equal(5);
+    });
+
     it('length of "hi" is 2',function(){
       expect(strlen('hi')).to.equal(2);
     });


### PR DESCRIPTION
I'm not 100% sure if this is the right way to go about it, but I wanted to display a table with some "fake" strikethrough in it. The [relevant character](http://www.fileformat.info/info/unicode/char/0336/index.htm) was throwing off the length calculation. It can safely be ignored. I've added it to the utils regex and added a test for it.

<img width="568" alt="screen shot 2018-03-12 at 16 48 52" src="https://user-images.githubusercontent.com/1507745/37294251-b4395e3e-2615-11e8-8f6e-4ac924335887.png">
