### PR TITLE
Update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-table2",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pretty unicode tables for the command line. Based on the original cli-table.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Dependencies, such as lodash, have been removed, but the version was never bumped. This bumps the version so the changes can be properly published.