### PR TITLE
Docs and tests for header logic

### DIFF
--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -17,6 +17,20 @@
 
 ```
 
+##### colSpan works with headers too:
+    ┌───────────┬────────┐
+    │ foobar    │ bazbar │
+    ├─────┬─────┼────────┤
+    │ foo │ bar │ baz    │
+    └─────┴─────┴────────┘
+```javascript
+      var table = new Table({
+        style: {border:[], head: []},
+        head:[{content: 'foobar', colSpan: 2}, {content: 'bazbar'}]
+      });
+
+      table.push(['foo', 'bar', 'baz']);
+```
 
 ##### use colSpan to span columns - (colSpan below normal cell)
     ┌───────┬───────┐

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -69,6 +69,64 @@ describe('@api Table ',function(){
 
     expect(table.toString()).to.equal(expected.join("\n"));
   });
+
+  it('will render head with text', function() {
+      var table = new Table({
+          style: {border:[], head: []},
+          head:['foobar', 'barbar', 'bazbar'],
+      });
+
+      table.push(['foo', 'bar', 'baz']);
+
+      var expected = [
+           '┌────────┬────────┬────────┐'
+          ,'│ foobar │ barbar │ bazbar │'
+          ,'├────────┼────────┼────────┤'
+          ,'│ foo    │ bar    │ baz    │'
+          ,'└────────┴────────┴────────┘'
+      ];
+
+      expect(table.toString()).to.equal(expected.join('\n'));
+  });
+
+  it('will render head with Cells', function() {
+      var table = new Table({
+          style: {border:[], head: []},
+          head:[{content: 'foobar'}, {content: 'barbar'}, {content: 'bazbar'}],
+      });
+
+      table.push(['foo', 'bar', 'baz']);
+
+      var expected = [
+           '┌────────┬────────┬────────┐'
+          ,'│ foobar │ barbar │ bazbar │'
+          ,'├────────┼────────┼────────┤'
+          ,'│ foo    │ bar    │ baz    │'
+          ,'└────────┴────────┴────────┘'
+      ];
+
+      expect(table.toString()).to.equal(expected.join('\n'));
+  });
+
+  it('will render colSpan in head correctly', function() {
+      var table = new Table({
+          style: {border:[], head: []},
+          head:[{content: 'foobar', colSpan: 2}, {content: 'bazbar'}],
+      });
+
+      table.push(['foo', 'bar', 'baz']);
+
+
+      var expected = [
+           '┌───────────┬────────┐'
+          ,'│ foobar    │ bazbar │'
+          ,'├─────┬─────┼────────┤'
+          ,'│ foo │ bar │ baz    │'
+          ,'└─────┴─────┴────────┘'
+      ];
+
+      expect(table.toString()).to.equal(expected.join('\n'));
+  });
 });
 
 


### PR DESCRIPTION
Hi!

While I've been rewriting my app to TypeScript and I've discovered that `head` type in `TableOptions` in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/924faff/types/cli-table2/index.d.ts#L34) is `string[]`, while it actually accepts `Cell[]` ([this type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cli-table2/index.d.ts#L78)).

So, I was going to make fix there, but couldn't find that `head` accepts `Cell[]` anywhere in docs or tests. So.. I've added some.
I'd be glad if you'd pull this commit.
