### PR TITLE
Bump version to 0.2.1 to fix npm security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-table2",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pretty unicode tables for the command line. Based on the original cli-table.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
The issue: https://www.npmjs.com/advisories/577

Bumping lib version and publishing the new version 0.2.1 to npm should fix it because a while back lodash dependency was removed.